### PR TITLE
Fix chars be with trailing whitespace parser error

### DIFF
--- a/lib/handler.ex
+++ b/lib/handler.ex
@@ -13,7 +13,6 @@ defmodule SAXMap.Handler do
         {stack, %{ignore_attribute: true} = options}
       ) do
     tag = {tag_name, nil}
-
     {:ok, {[tag | stack], options}}
   end
 
@@ -51,6 +50,14 @@ defmodule SAXMap.Handler do
   end
 
   def handle_event(:characters, "\n" <> _, state) do
+    {:ok, state}
+  end
+
+  def handle_event(:characters, " " <> _, {[{_not_start_element, _}] = _stack, _} = state) do
+    # Some cases characters starts with whitespace:
+    #   case1  ```<xml><a>1<a> \n</xml>
+    #   case2  ```<xml><a> 1<a></xml>
+    # if in case1, we need to ignore whitespace part and keep on-going
     {:ok, state}
   end
 
@@ -252,4 +259,5 @@ defmodule SAXMap.Handler do
   defp put_or_concat_to_map(current_value, map, key, value) do
     Map.put(map, key, [value, current_value])
   end
+
 end

--- a/lib/handler.ex
+++ b/lib/handler.ex
@@ -53,7 +53,7 @@ defmodule SAXMap.Handler do
     {:ok, state}
   end
 
-  def handle_event(:characters, " " <> _, {[{_not_start_element, _}] = _stack, _} = state) do
+  def handle_event(:characters, " " <> _, {[{_not_end_tag, _}] = _stack, _} = state) do
     # Some cases characters starts with whitespace:
     #   case1  ```<xml><a>1<a> \n</xml>
     #   case2  ```<xml><a> 1<a></xml>

--- a/test/sax_map_test.exs
+++ b/test/sax_map_test.exs
@@ -392,4 +392,41 @@ defmodule SAXMapTest do
     assert map["xml"]["Content"] == "\n  ."
   end
 
+  test "parse trailing whitespace when process characters" do
+    # Note the single trailing space character after <a></a>,
+    # the following xml is ```<xml>\n<a></a> \n<b></b>\n</xml>\n```
+    xml = """
+    <xml>
+    <a></a> 
+    <b></b>
+    </xml>
+    """
+
+    {:ok, map} = SAXMap.from_string(xml)
+    assert map == %{"xml" => %{"a" => nil, "b" => nil}}
+
+    xml = """
+    <xml>
+    <a>  1  </a> 
+    <b>1</b> 
+    <c>1 </c>
+    <d> 1 </d>
+    </xml>
+    """
+
+    {:ok, map} = SAXMap.from_string(xml)
+    assert map == %{"xml" => %{"a" => "  1  ", "b" => "1", "c" => "1 ", "d" => " 1 "}}
+  end
+
+  test "parse invalid characters will be ignored" do
+    xml = """
+    <xml>
+    <a></a> invalid be ignored
+    <b></b>
+    </xml>
+    """
+    {:ok, map} = SAXMap.from_string(xml)
+    assert map == %{"xml" => %{"a" => nil, "b" => nil}}
+  end
+
 end


### PR DESCRIPTION
Related https://github.com/xinz/sax_map/issues/7