### PR TITLE
Ignore unexpected characters when parse element data

### DIFF
--- a/lib/handler.ex
+++ b/lib/handler.ex
@@ -53,11 +53,11 @@ defmodule SAXMap.Handler do
     {:ok, state}
   end
 
-  def handle_event(:characters, " " <> _, {[{_not_end_tag, _}] = _stack, _} = state) do
-    # Some cases characters starts with whitespace:
-    #   case1  ```<xml><a>1<a> \n</xml>
-    #   case2  ```<xml><a> 1<a></xml>
-    # if in case1, we need to ignore whitespace part and keep on-going
+  def handle_event(:characters, _chars_not_in_expected_element_pair, {[{_not_end_tag, prepared}] = _stack, _} = state) when prepared != nil do
+    # When characters are not in the expected element pair:
+    #   ```<xml><a>1<a> \n</xml>```
+    #   ```<xml><a>1<a>unexpected content<c>2</c></xml>```
+    # The " \n" and "unexpected content" will be ignored
     {:ok, state}
   end
 

--- a/test/sax_map_test.exs
+++ b/test/sax_map_test.exs
@@ -418,15 +418,24 @@ defmodule SAXMapTest do
     assert map == %{"xml" => %{"a" => "  1  ", "b" => "1", "c" => "1 ", "d" => " 1 "}}
   end
 
-  test "parse invalid characters will be ignored" do
+  test "parse unexpected characters will be ignored" do
     xml = """
     <xml>
-    <a></a> invalid be ignored
+    <a></a> unexpected be ignored
     <b></b>
     </xml>
     """
     {:ok, map} = SAXMap.from_string(xml)
     assert map == %{"xml" => %{"a" => nil, "b" => nil}}
+
+    xml = """
+    <xml>
+    <a>2</a>some unexpected be ignored
+    <b>1</b>yes ignore it
+    </xml>
+    """
+    {:ok, map} = SAXMap.from_string(xml)
+    assert map == %{"xml" => %{"a" => "2", "b" => "1"}}
   end
 
 end


### PR DESCRIPTION
Related #7 issue.

This PR follows up some changes from pull #8 and make the unexpected characters will be ignored in the same behavior and result.

In fact, the following XML content is verified without any syntax error, but it should be not make sense(in my opinion, so far) to process it as an expected map, so this PR makes some content will be ignored in the following similar cases.

```xml
<a>
    some content
    <b/>
</a>
```

More examples:

```elixir
test "parse unexpected characters will be ignored" do
  xml = """
  <xml>
  <a></a> unexpected be ignored
  <b></b>
  </xml>
  """
  {:ok, map} = SAXMap.from_string(xml)
  assert map == %{"xml" => %{"a" => nil, "b" => nil}}

  xml = """
  <xml>
  <a>2</a>some unexpected be ignored
  <b>1</b>yes ignore it
  </xml>
  """
  {:ok, map} = SAXMap.from_string(xml)
  assert map == %{"xml" => %{"a" => "2", "b" => "1"}}
end
```
