### PR TITLE
Handle text nodes starting with newlines

### DIFF
--- a/test/sax_map_test.exs
+++ b/test/sax_map_test.exs
@@ -453,4 +453,19 @@ defmodule SAXMapTest do
     assert map == %{"xml" => %{"a" => "2", "b" => "1"}}
   end
 
+  test "text node starting with newline" do
+    xml = """
+    <xml>
+    <a>
+    1
+    </a>
+    <b>
+    2
+    </b>
+    </xml>
+    """
+    {:ok, map} = SAXMap.from_string(xml)
+    assert map == %{"xml" => %{"a" => "\n1\n", "b" => "\n2\n"}}
+  end
+
 end


### PR DESCRIPTION
Using this library to parse the coordinates out of some KML files, we found that when the text of a node starts with a newline, the text was dropped in it's entirety and the resulting value would be nil (so the new test would produce a map of `%{"xml" => %{"a" => nil, "b" => nil}}`. This changes the newline handling to only discard strings that are wholly white-space.