### PR TITLE
Clean up the code

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,40 +111,85 @@ Output:
 
 ```bash
 Operating System: macOS
-CPU Information: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
-Number of Available Cores: 16
-Available memory: 32 GB
-Elixir 1.12.2
-Erlang 24.0.4
+CPU Information: Apple M2 Pro
+Number of Available Cores: 10
+Available memory: 16 GB
+Elixir 1.19.5
+Erlang 28.2
+JIT enabled: true
 
 Benchmark suite executing with the following configuration:
 warmup: 2 s
 time: 10 s
 memory time: 2 s
+reduction time: 0 ns
 parallel: 1
 inputs: none specified
-Estimated total run time: 42 s
+Estimated total run time: 56 s
 
-Benchmarking SAXMap.from_string ignore attribute...
-Benchmarking SAXMap.from_string with attribute...
-Benchmarking XmlToMap.naive_map...
+Benchmarking SAXMap.from_string ignore attribute ...
+Benchmarking SAXMap.from_string with attribute ...
+Benchmarking XmlToMap.naive_map ignore attribute ...
+Benchmarking XmlToMap.nested_map with attribute ...
+Calculating statistics...
+Formatting results...
 
 Name                                          ips        average  deviation         median         99th %
-SAXMap.from_string ignore attribute      105.03 K        9.52 μs   ±129.42%           9 μs          33 μs
-SAXMap.from_string with attribute         96.74 K       10.34 μs   ±110.08%           9 μs          35 μs
-XmlToMap.naive_map                        26.31 K       38.01 μs    ±46.21%          33 μs         105 μs
+SAXMap.from_string ignore attribute      200.24 K        4.99 μs   ±224.70%        4.75 μs        8.79 μs
+SAXMap.from_string with attribute        189.12 K        5.29 μs   ±219.38%        5.04 μs       10.58 μs
+XmlToMap.nested_map with attribute       183.05 K        5.46 μs   ±151.45%        5.25 μs       13.79 μs
+XmlToMap.naive_map ignore attribute      144.77 K        6.91 μs   ±137.97%        6.58 μs       16.17 μs
 
 Comparison:
-SAXMap.from_string ignore attribute      105.03 K
-SAXMap.from_string with attribute         96.74 K - 1.09x slower +0.82 μs
-XmlToMap.naive_map                        26.31 K - 3.99x slower +28.49 μs
+SAXMap.from_string ignore attribute      200.24 K
+SAXMap.from_string with attribute        189.12 K - 1.06x slower +0.29 μs
+XmlToMap.nested_map with attribute       183.05 K - 1.09x slower +0.47 μs
+XmlToMap.naive_map ignore attribute      144.77 K - 1.38x slower +1.91 μs
 
 Memory usage statistics:
 
 Name                                   Memory usage
-SAXMap.from_string ignore attribute        14.61 KB
-SAXMap.from_string with attribute          16.69 KB - 1.14x memory usage +2.08 KB
-XmlToMap.naive_map                         40.90 KB - 2.80x memory usage +26.29 KB
+SAXMap.from_string ignore attribute        14.98 KB
+SAXMap.from_string with attribute          16.17 KB - 1.08x memory usage +1.20 KB
+XmlToMap.nested_map with attribute         31.62 KB - 2.11x memory usage +16.64 KB
+XmlToMap.naive_map ignore attribute        34.26 KB - 2.29x memory usage +19.28 KB
+
+**All measurements for memory usage were the same**
+Operating System: macOS
+CPU Information: Apple M2 Pro
+Number of Available Cores: 10
+Available memory: 16 GB
+Elixir 1.19.5
+Erlang 28.2
+JIT enabled: true
+
+Benchmark suite executing with the following configuration:
+warmup: 2 s
+time: 10 s
+memory time: 2 s
+reduction time: 0 ns
+parallel: 1
+inputs: none specified
+Estimated total run time: 28 s
+
+Benchmarking SAXMap.from_string mixed content ...
+Benchmarking XmlToMap.nested_map mixed content ...
+Calculating statistics...
+Formatting results...
+
+Name                                        ips        average  deviation         median         99th %
+SAXMap.from_string mixed content         556.11        1.80 ms     ±7.62%        1.77 ms        2.08 ms
+XmlToMap.nested_map mixed content        455.80        2.19 ms     ±7.48%        2.18 ms        2.70 ms
+
+Comparison:
+SAXMap.from_string mixed content         556.11
+XmlToMap.nested_map mixed content        455.80 - 1.22x slower +0.40 ms
+
+Memory usage statistics:
+
+Name                                 Memory usage
+SAXMap.from_string mixed content          6.04 MB
+XmlToMap.nested_map mixed content         9.47 MB - 1.57x memory usage +3.43 MB
 
 **All measurements for memory usage were the same**
 ```

--- a/bench/README.md
+++ b/bench/README.md
@@ -1,8 +1,20 @@
 # Bench
 
-Go into the current directory and execute the following command to run the benchmark.
+Go into this directory and run one of the following benchmarks.
+
+## General comparison
 
 ```bash
-$ mix bench.xml_to_map
+mix bench.xml_to_map
 ```
+
+## Handler refactor comparison
+
+```bash
+mix bench.refactor_comparison
+```
+
+This benchmark compares the copied pre-refactor handler with the current
+`SAXMap.Handler` using identical inputs. It verifies that both implementations
+produce the same output before Benchee starts timing them.
 

--- a/bench/lib/handler/pre_refactor.ex
+++ b/bench/lib/handler/pre_refactor.ex
@@ -1,0 +1,259 @@
+# Copy of `lib/handler.ex` before the accumulator refactor.
+#
+# This module exists only to provide a stable, in-process baseline for
+# `bench/refactor_comparison.exs`.
+defmodule SAXMap.Bench.Handler.PreRefactor do
+  @moduledoc false
+
+  @behaviour Saxy.Handler
+
+  # The key name of internal text content when process XML mixed content
+  @key_text_content "_#{__MODULE__}.TextContent_"
+
+  # The key name of the transfer map result for the text content
+  # part extracted from the original XML data
+  @key_content "content"
+
+  def handle_event(:start_document, _prolog, opts) do
+    ignore_attribute = Keyword.get(opts, :ignore_attribute, true)
+    simplified_ignore_attr = simplify_ignore_attribute_opt(ignore_attribute)
+    {:ok, {[], ignore_attribute, simplified_ignore_attr}}
+  end
+
+  def handle_event(:start_element, element, {stack, ignore_attribute, simplified_ignore_attr}) do
+    stack = handle_start_element(element, stack, ignore_attribute)
+    {:ok, {stack, ignore_attribute, simplified_ignore_attr}}
+  end
+
+  def handle_event(:cdata, cdata, {stack, ignore_attribute, simplified_ignore_attr}) do
+    stack = handle_cdata(cdata, stack)
+    {:ok, {stack, ignore_attribute, simplified_ignore_attr}}
+  end
+
+  def handle_event(:characters, chars, {stack, ignore_attribute, simplified_ignore_attr}) do
+    stack = handle_characters(chars, stack, simplified_ignore_attr)
+    {:ok, {stack, ignore_attribute, simplified_ignore_attr}}
+  end
+
+  def handle_event(:end_element, _tag_name, {stack, ignore_attribute, simplified_ignore_attr}) do
+    stack = handle_end_element(stack, simplified_ignore_attr)
+    {:ok, {stack, ignore_attribute, simplified_ignore_attr}}
+  end
+
+  def handle_event(:end_document, _, {stack, _ignore_attribute, simplified_ignore_attr}) do
+    result = handle_end_document(stack, simplified_ignore_attr)
+    {:ok, result}
+  end
+
+  defp format_key_value_pairs(items) when is_list(items) do
+    list_to_map(items, %{})
+  end
+
+  defp format_key_value_pairs(item) do
+    item
+  end
+
+  defp list_to_map([], prepared) do
+    prepared
+  end
+
+  defp list_to_map([%{@key_text_content => text_items} | rest], prepared) do
+    # Use "content" instead of @key_text_content as the key name
+    list_to_map(rest, Map.put(prepared, @key_content, Enum.reverse(text_items)))
+  end
+
+  defp list_to_map([map | rest], prepared) when map_size(map) == 0 do
+    # Empty map as `%{}`
+    list_to_map(rest, prepared)
+  end
+
+  defp list_to_map([item | rest], prepared) when is_map(item) do
+    [key | _] = Map.keys(item)
+    value = Map.get(item, key)
+    existed_value = Map.get(prepared, key)
+    prepared = put_or_concat_to_map(existed_value, prepared, key, value)
+    list_to_map(rest, prepared)
+  end
+
+  defp list_to_map([{key, value} | rest], prepared) do
+    existed_value = Map.get(prepared, key)
+    prepared = put_or_concat_to_map(existed_value, prepared, key, value)
+    list_to_map(rest, prepared)
+  end
+
+  @compile {:inline, put_or_concat_to_map: 4}
+  defp put_or_concat_to_map(nil, map, key, value) do
+    Map.put(map, key, value)
+  end
+
+  defp put_or_concat_to_map(current_value, map, key, value) when is_list(current_value) do
+    Map.put(map, key, [value | current_value])
+  end
+
+  defp put_or_concat_to_map(current_value, map, key, value) do
+    Map.put(map, key, [value, current_value])
+  end
+
+  defp ignore_or_extract_characters(chars, stack, value) do
+    if all_whitespace?(chars) do
+      # ignore
+      stack
+    else
+      extract_characters_into_tag(chars, stack, value)
+    end
+  end
+
+  @compile {:inline, all_whitespace?: 1}
+  defp all_whitespace?(<<>>), do: true
+
+  defp all_whitespace?(<<char, rest::binary>>) when char in [?\s, ?\t, ?\n, ?\r] do
+    all_whitespace?(rest)
+  end
+
+  defp all_whitespace?(_), do: false
+
+  defp extract_characters_into_tag(chars, [{tag_name, content} | rest], true) do
+    [{tag_name, append_characters_text_content(content, chars)} | rest]
+  end
+
+  defp extract_characters_into_tag(chars, [{tag_name, attributes, content} | rest], false) do
+    [{tag_name, attributes, append_characters_text_content(content, chars)} | rest]
+  end
+
+  defp prepare_stack_text_when_start_element([{key, value} | rest]) when is_bitstring(value) do
+    [{key, [%{@key_text_content => [value]}]} | rest]
+  end
+
+  defp prepare_stack_text_when_start_element([{key, attributes, value} | rest]) when is_bitstring(value) do
+    [{key, attributes, [%{@key_text_content => [value]}]} | rest]
+  end
+
+  defp prepare_stack_text_when_start_element(stack), do: stack
+
+  defp append_characters_text_content(nil, chars), do: chars
+
+  defp append_characters_text_content(content, chars) when is_list(content) do
+    append_characters_to_content(Enum.reverse(content), chars, [])
+  end
+
+  defp append_characters_to_content([], chars, acc) do
+    [%{@key_text_content => [chars]} | acc]
+  end
+
+  defp append_characters_to_content([%{@key_text_content => text_items} | rest], chars, acc) do
+    [%{@key_text_content => [chars | text_items]} | rest] ++ acc
+  end
+
+  defp append_characters_to_content([item | rest], chars, acc) do
+    append_characters_to_content(rest, chars, [item | acc])
+  end
+
+  defp handle_start_element({tag_name, _attributes}, stack, true) do
+    stack = prepare_stack_text_when_start_element(stack)
+    [{tag_name, nil} | stack]
+  end
+
+  defp handle_start_element({tag_name, attributes}, stack, false) do
+    stack = prepare_stack_text_when_start_element(stack)
+    [{tag_name, attributes, nil} | stack]
+  end
+
+  defp handle_start_element({tag_name, attributes}, stack, {false, attribute_prefix}) do
+    stack = prepare_stack_text_when_start_element(stack)
+    attributes = map_attribute_prefix(attributes, attribute_prefix, [])
+    [{tag_name, attributes, nil} | stack]
+  end
+
+  defp map_attribute_prefix([], _prefix, acc), do: Enum.reverse(acc)
+
+  defp map_attribute_prefix([{key, value} | rest], prefix, acc) do
+    map_attribute_prefix(rest, prefix, [{prefix <> key, value} | acc])
+  end
+
+  defp handle_cdata(cdata, [{tag_name, _} | rest]) do
+    [{tag_name, cdata} | rest]
+  end
+
+  defp handle_cdata(cdata, [{tag_name, attributes, _} | rest]) do
+    [{tag_name, attributes, cdata} | rest]
+  end
+
+  defp handle_characters("\r" <> _ = data, stack, value) do
+    ignore_or_extract_characters(data, stack, value)
+  end
+
+  defp handle_characters("\n" <> _ = data, stack, value) do
+    ignore_or_extract_characters(data, stack, value)
+  end
+
+  defp handle_characters(data, [{_not_end_tag, prepared}] = stack, value) when prepared != nil do
+    ignore_or_extract_characters(data, stack, value)
+  end
+
+  defp handle_characters(data, stack, value) do
+    extract_characters_into_tag(data, stack, value)
+  end
+
+  defp handle_end_element([{tag_name, content}], true) do
+    {tag_name, content}
+  end
+
+  defp handle_end_element([{tag_name, attributes, content}], false) do
+    {tag_name, attributes, content}
+  end
+
+  defp handle_end_element([{tag_name, content} | [{parent_tag_name, nil} | rest]], true) do
+    current = {tag_name, format_key_value_pairs(content)}
+    [{parent_tag_name, [current]} | rest]
+  end
+
+  defp handle_end_element(
+         [{tag_name, attributes, content} | [{parent_tag_name, parent_attributes, nil} | rest]],
+         false
+       ) do
+    formated_content = format_key_value_pairs(content)
+    current = %{tag_name => format_key_value_pairs([{@key_content, formated_content} | attributes])}
+    [{parent_tag_name, parent_attributes, [current]} | rest]
+  end
+
+  defp handle_end_element([{tag_name, content} | [{parent_tag_name, parent_content} | rest]], true) do
+    current = {tag_name, format_key_value_pairs(content)}
+    [{parent_tag_name, [current | parent_content]} | rest]
+  end
+
+  defp handle_end_element(
+         [
+           {tag_name, attributes, content}
+           | [{parent_tag_name, parent_attributes, parent_content} | rest]
+         ],
+         false
+       ) do
+    formated_content = format_key_value_pairs(content)
+    current = %{tag_name => format_key_value_pairs([{@key_content, formated_content} | attributes])}
+    [{parent_tag_name, parent_attributes, [current | parent_content]} | rest]
+  end
+
+  defp handle_end_document({key, nil}, true) do
+    %{key => %{}}
+  end
+
+  defp handle_end_document({key, value}, true) do
+    %{key => format_key_value_pairs(value)}
+  end
+
+  defp handle_end_document({key, attributes, nil}, false) do
+    %{key => format_key_value_pairs(attributes)}
+  end
+
+  defp handle_end_document({key, attributes, value}, false) do
+    value =
+      format_key_value_pairs(attributes) |> Map.put(@key_content, format_key_value_pairs(value))
+
+    %{key => value}
+  end
+
+  @compile {:inline, simplify_ignore_attribute_opt: 1}
+  defp simplify_ignore_attribute_opt(true), do: true
+  defp simplify_ignore_attribute_opt(false), do: false
+  defp simplify_ignore_attribute_opt({false, _}), do: false
+end

--- a/bench/lib/sax_map/pre_refactor.ex
+++ b/bench/lib/sax_map/pre_refactor.ex
@@ -1,0 +1,16 @@
+defmodule SAXMap.Bench.PreRefactor do
+  @moduledoc false
+
+  @spec from_string(xml :: String.t(), opts :: keyword()) ::
+          {:ok, map :: map()} | {:error, exception :: Saxy.ParseError.t()}
+  def from_string(xml, opts \\ []) do
+    ignore_attribute = Keyword.get(opts, :ignore_attribute, true)
+
+    Saxy.parse_string(
+      xml,
+      SAXMap.Bench.Handler.PreRefactor,
+      [ignore_attribute: ignore_attribute],
+      cdata_as_characters: false
+    )
+  end
+end

--- a/bench/mix.exs
+++ b/bench/mix.exs
@@ -20,7 +20,8 @@ defmodule Bench.MixProject do
 
   defp aliases() do
     [
-      "bench.xml_to_map": ["run xml_to_map.exs"]
+      "bench.xml_to_map": ["run xml_to_map.exs"],
+      "bench.refactor_comparison": ["run refactor_comparison.exs"]
     ]
   end
 

--- a/bench/refactor_comparison.exs
+++ b/bench/refactor_comparison.exs
@@ -1,0 +1,37 @@
+alias SAXMap.Bench.PreRefactor
+
+mixed_content_xml =
+  "<root>" <>
+    String.duplicate("<p>" <> String.duplicate("s<b>1</b>", 200) <> "e</p>", 20) <>
+    "</root>"
+
+attribute_dense_xml =
+  "<root>" <>
+    String.duplicate("<item alpha=\"1\" beta=\"2\" gamma=\"3\">text</item>", 2_000) <>
+    "</root>"
+
+inputs = %{
+  "alternating mixed content" => {mixed_content_xml, []},
+  "attribute-dense" => {attribute_dense_xml, [ignore_attribute: false]},
+  "attribute-dense with @ prefix" => {attribute_dense_xml, [ignore_attribute: {false, "@"}]}
+}
+
+Enum.each(inputs, fn {name, {xml, opts}} ->
+  before = PreRefactor.from_string(xml, opts)
+  refactored = SAXMap.from_string(xml, opts)
+
+  if before != refactored do
+    raise "before and after results differ for #{name}"
+  end
+end)
+
+Benchee.run(
+  %{
+    "Before refactor" => fn {xml, opts} -> PreRefactor.from_string(xml, opts) end,
+    "After refactor" => fn {xml, opts} -> SAXMap.from_string(xml, opts) end
+  },
+  inputs: inputs,
+  time: 10,
+  memory_time: 2,
+  parallel: 1
+)

--- a/bench/xml_to_map.exs
+++ b/bench/xml_to_map.exs
@@ -21,7 +21,24 @@ Benchee.run(
     "SAXMap.from_string ignore attribute" => fn -> SAXMap.from_string(xml) end,
     "SAXMap.from_string with attribute" => fn -> SAXMap.from_string(xml, ignore_attribute: false) end,
     #"Simple Parser with Saxy.SimpleForm ignore attribute" => fn -> SAXMap.Bench.SimpleFormParser.from_string(xml) end,
-    "XmlToMap.naive_map" => fn -> XmlToMap.naive_map(xml) end
+    "XmlToMap.naive_map ignore attribute" => fn -> XmlToMap.naive_map(xml) end,
+    "XmlToMap.nested_map with attribute" => fn -> XmlToMap.nested_map(xml) end
+  },
+  time: 10,
+  memory_time: 2
+)
+
+# XML with heavy mixed content (interleaved text chunks and child elements)
+# to exercise the text accumulation path
+mixed_xml =
+  "<root>" <>
+    String.duplicate("<p>" <> String.duplicate("s<b>1</b>", 200) <> "e</p>", 20) <>
+    "</root>"
+
+Benchee.run(
+  %{
+    "SAXMap.from_string mixed content" => fn -> SAXMap.from_string(mixed_xml) end,
+    "XmlToMap.nested_map mixed content" => fn -> XmlToMap.nested_map(mixed_xml) end
   },
   time: 10,
   memory_time: 2

--- a/lib/handler.ex
+++ b/lib/handler.ex
@@ -3,42 +3,46 @@ defmodule SAXMap.Handler do
 
   @behaviour Saxy.Handler
 
-  # The key name of internal text content when process XML mixed content
-  @key_text_content "_#{__MODULE__}.TextContent_"
-
   # The key name of the transfer map result for the text content
   # part extracted from the original XML data
   @key_content "content"
 
+  # Stack entry formats:
+  #
+  #   ignore_attribute: true  -> {tag_name, text, children}
+  #   ignore_attribute: false -> {tag_name, attributes, text, children}
+  #
+  # `text` is nil, a single binary, or a list of text chunks in reverse order.
+  # `children` is a list of {tag_name, value} entries in reverse document order.
+  # Both accumulators use O(1) head-prepends and are finalized only when their
+  # enclosing element closes.
+
   def handle_event(:start_document, _prolog, opts) do
-    ignore_attribute = Keyword.get(opts, :ignore_attribute, true)
-    simplified_ignore_attr = simplify_ignore_attribute_opt(ignore_attribute)
-    {:ok, {[], ignore_attribute, simplified_ignore_attr}}
+    mode = normalize_ignore_attribute(Keyword.get(opts, :ignore_attribute, true))
+    {:ok, {[], mode}}
   end
 
-  def handle_event(:start_element, element, {stack, ignore_attribute, simplified_ignore_attr}) do
-    stack = handle_start_element(element, stack, ignore_attribute)
-    {:ok, {stack, ignore_attribute, simplified_ignore_attr}}
+  def handle_event(:start_element, element, {stack, mode}) do
+    {:ok, {handle_start_element(element, stack, mode), mode}}
   end
 
-  def handle_event(:cdata, cdata, {stack, ignore_attribute, simplified_ignore_attr}) do
-    stack = handle_cdata(cdata, stack)
-    {:ok, {stack, ignore_attribute, simplified_ignore_attr}}
+  def handle_event(:cdata, cdata, {stack, mode}) do
+    {:ok, {handle_cdata(cdata, stack), mode}}
   end
 
-  def handle_event(:characters, chars, {stack, ignore_attribute, simplified_ignore_attr}) do
-    stack = handle_characters(chars, stack, simplified_ignore_attr)
-    {:ok, {stack, ignore_attribute, simplified_ignore_attr}}
+  def handle_event(:characters, chars, {stack, mode} = state) do
+    case handle_characters(chars, stack, mode) do
+      nil -> {:ok, state}
+      updated_stack -> {:ok, {updated_stack, mode}}
+    end
   end
 
-  def handle_event(:end_element, _tag_name, {stack, ignore_attribute, simplified_ignore_attr}) do
-    stack = handle_end_element(stack, simplified_ignore_attr)
-    {:ok, {stack, ignore_attribute, simplified_ignore_attr}}
+  def handle_event(:end_element, _tag_name, {stack, mode}) do
+    {:ok, {handle_end_element(stack, mode), mode}}
   end
 
-  def handle_event(:end_document, _, {stack, _ignore_attribute, simplified_ignore_attr}) do
-    result = handle_end_document(stack, simplified_ignore_attr)
-    {:ok, result}
+  def handle_event(:end_document, _, {stack, mode}) do
+    {:ok, handle_end_document(stack, mode)}
   end
 
   defp format_key_value_pairs(items) when is_list(items) do
@@ -53,31 +57,23 @@ defmodule SAXMap.Handler do
     prepared
   end
 
-  defp list_to_map([%{@key_text_content => text_items} | rest], prepared) do
-    # Use "content" instead of @key_text_content as the key name
-    list_to_map(rest, Map.put(prepared, @key_content, Enum.reverse(text_items)))
-  end
-
-  defp list_to_map([map | rest], prepared) when map_size(map) == 0 do
-    # Empty map as `%{}`
-    list_to_map(rest, prepared)
-  end
-
-  defp list_to_map([item | rest], prepared) when is_map(item) do
-    [key | _] = Map.keys(item)
-    value = Map.get(item, key)
-    existed_value = Map.get(prepared, key)
-    prepared = put_or_concat_to_map(existed_value, prepared, key, value)
-    list_to_map(rest, prepared)
-  end
-
   defp list_to_map([{key, value} | rest], prepared) do
     existed_value = Map.get(prepared, key)
     prepared = put_or_concat_to_map(existed_value, prepared, key, value)
     list_to_map(rest, prepared)
   end
 
-  @compile {:inline, put_or_concat_to_map: 4}
+  defp list_to_map_with_prefix([], _prefix, prepared) do
+    prepared
+  end
+
+  defp list_to_map_with_prefix([{key, value} | rest], prefix, prepared) do
+    key = prefix <> key
+    existed_value = Map.get(prepared, key)
+    prepared = put_or_concat_to_map(existed_value, prepared, key, value)
+    list_to_map_with_prefix(rest, prefix, prepared)
+  end
+
   defp put_or_concat_to_map(nil, map, key, value) do
     Map.put(map, key, value)
   end
@@ -90,135 +86,188 @@ defmodule SAXMap.Handler do
     Map.put(map, key, [value, current_value])
   end
 
-  defp ignore_or_extract_characters(chars, stack, value) do
+  defp ignore_or_extract_characters(chars, stack, mode) do
     if all_whitespace?(chars) do
-      # ignore
-      stack
+      nil
     else
-      extract_characters_into_tag(chars, stack, value)
+      extract_characters_into_tag(chars, stack, mode)
     end
   end
 
-  @compile {:inline, all_whitespace?: 1}
   defp all_whitespace?(<<>>), do: true
+
   defp all_whitespace?(<<char, rest::binary>>) when char in [?\s, ?\t, ?\n, ?\r] do
     all_whitespace?(rest)
   end
+
   defp all_whitespace?(_), do: false
 
-  defp extract_characters_into_tag(chars, [{tag_name, content} | rest], true) do
-    [{tag_name, append_characters_text_content(content, chars)} | rest]
-  end
-
-  defp extract_characters_into_tag(chars, [{tag_name, attributes, content} | rest], false) do
-    [{tag_name, attributes, append_characters_text_content(content, chars)} | rest]
-  end
-
-  defp prepare_stack_text_when_start_element([{key, value} | rest]) when is_bitstring(value) do
-    [{key, [%{@key_text_content => [value]}]} | rest]
-  end
-  defp prepare_stack_text_when_start_element([{key, attributes, value} | rest]) when is_bitstring(value) do
-    [{key, attributes, [%{@key_text_content => [value]}]} | rest]
-  end
-  defp prepare_stack_text_when_start_element(stack), do: stack
-
   defp append_characters_text_content(nil, chars), do: chars
-  defp append_characters_text_content(content, chars) when is_list(content) do
-    append_characters_to_content(Enum.reverse(content), chars, [])
+
+  defp append_characters_text_content(text, chars) when is_binary(text) do
+    [chars, text]
   end
 
-  defp append_characters_to_content([], chars, acc) do
-    [%{@key_text_content => [chars]} | acc]
-  end
-  defp append_characters_to_content([%{@key_text_content => text_items} | rest], chars, acc) do
-    [%{@key_text_content => [chars | text_items]} | rest] ++ acc
-  end
-  defp append_characters_to_content([item | rest], chars, acc) do
-    append_characters_to_content(rest, chars, [item | acc])
+  defp append_characters_text_content(text, chars) when is_list(text) do
+    [chars | text]
   end
 
   defp handle_start_element({tag_name, _attributes}, stack, true) do
-    stack = prepare_stack_text_when_start_element(stack)
-    [{tag_name, nil} | stack]
+    [{tag_name, nil, []} | stack]
   end
+
   defp handle_start_element({tag_name, attributes}, stack, false) do
-    stack = prepare_stack_text_when_start_element(stack)
-    [{tag_name, attributes, nil} | stack]
-  end
-  defp handle_start_element({tag_name, attributes}, stack, {false, attribute_prefix}) do
-    stack = prepare_stack_text_when_start_element(stack)
-    attributes = map_attribute_prefix(attributes, attribute_prefix, [])
-    [{tag_name, attributes, nil} | stack]
+    [{tag_name, attributes, nil, []} | stack]
   end
 
-  defp map_attribute_prefix([], _prefix, acc), do: Enum.reverse(acc)
-  defp map_attribute_prefix([{key, value} | rest], prefix, acc) do
-    map_attribute_prefix(rest, prefix, [{prefix <> key, value} | acc])
+  defp handle_start_element({tag_name, attributes}, stack, {false, prefix}) when is_binary(prefix) do
+    [{tag_name, attributes, nil, []} | stack]
   end
 
-  defp handle_cdata(cdata, [{tag_name, _} | rest]) do
-    [{tag_name, cdata} | rest]
-  end
-  defp handle_cdata(cdata, [{tag_name, attributes, _} | rest]) do
-    [{tag_name, attributes, cdata} | rest]
+  defp handle_start_element({tag_name, []}, stack, {false, _prefix}) do
+    [{tag_name, [], nil, []} | stack]
   end
 
-  defp handle_characters("\r" <> _ = data, stack, value) do
-    ignore_or_extract_characters(data, stack, value)
-  end
-  defp handle_characters("\n" <> _ = data, stack, value) do
-    ignore_or_extract_characters(data, stack, value)
-  end
-  defp handle_characters(data, [{_not_end_tag, prepared}] = stack, value) when prepared != nil do
-    ignore_or_extract_characters(data, stack, value)
-  end
-  defp handle_characters(data, stack, value) do
-    extract_characters_into_tag(data, stack, value)
+  defp handle_start_element({tag_name, [{key, _value} | _] = attributes}, stack, {false, prefix}) do
+    _ = prefix <> key
+    [{tag_name, attributes, nil, []} | stack]
   end
 
-  defp handle_end_element([{tag_name, content}], true) do
-    {tag_name, content}
-  end
-  defp handle_end_element([{tag_name, attributes, content}], false) do
-    {tag_name, attributes, content}
-  end
-  defp handle_end_element([{tag_name, content} | [{parent_tag_name, nil} | rest]], true) do
-    current = {tag_name, format_key_value_pairs(content)}
-    [{parent_tag_name, [current]} | rest]
-  end
-  defp handle_end_element([{tag_name, attributes, content} | [{parent_tag_name, parent_attributes, nil} | rest]], false) do
-    formated_content = format_key_value_pairs(content)
-    current = %{tag_name => format_key_value_pairs([{@key_content, formated_content} | attributes])}
-    [{parent_tag_name, parent_attributes, [current]} | rest]
-  end
-  defp handle_end_element([{tag_name, content} | [{parent_tag_name, parent_content} | rest]], true) do
-    current = {tag_name, format_key_value_pairs(content)}
-    [{parent_tag_name, [current | parent_content]} | rest]
-  end
-  defp handle_end_element([{tag_name, attributes, content} | [{parent_tag_name, parent_attributes, parent_content} | rest]], false) do
-    formated_content = format_key_value_pairs(content)
-    current = %{tag_name => format_key_value_pairs([{@key_content, formated_content} | attributes])}
-    [{parent_tag_name, parent_attributes, [current | parent_content]} | rest]
+  # Preserve the existing CDATA event semantics: a CDATA event replaces the
+  # current element's accumulated content.
+  defp handle_cdata(cdata, [{tag_name, _text, _children} | rest]) do
+    [{tag_name, cdata, []} | rest]
   end
 
-  defp handle_end_document({key, nil}, true) do
+  defp handle_cdata(cdata, [{tag_name, attributes, _text, _children} | rest]) do
+    [{tag_name, attributes, cdata, []} | rest]
+  end
+
+  defp handle_characters("\r" <> _ = data, stack, mode) do
+    ignore_or_extract_characters(data, stack, mode)
+  end
+
+  defp handle_characters("\n" <> _ = data, stack, mode) do
+    ignore_or_extract_characters(data, stack, mode)
+  end
+
+  defp handle_characters(data, [{_tag_name, text, children}] = stack, true)
+       when text != nil or children != [] do
+    ignore_or_extract_characters(data, stack, true)
+  end
+
+  defp handle_characters(data, stack, mode) do
+    extract_characters_into_tag(data, stack, mode)
+  end
+
+  defp extract_characters_into_tag(chars, [{tag_name, text, children} | rest], true) do
+    [{tag_name, append_characters_text_content(text, chars), children} | rest]
+  end
+
+  defp extract_characters_into_tag(
+         chars,
+         [{tag_name, attributes, text, children} | rest],
+         _attribute_mode
+       ) do
+    [{tag_name, attributes, append_characters_text_content(text, chars), children} | rest]
+  end
+
+  defp handle_end_element([{tag_name, text, children}], true) do
+    {tag_name, text, children}
+  end
+
+  defp handle_end_element([{tag_name, attributes, text, children}], _attribute_mode) do
+    {tag_name, attributes, text, children}
+  end
+
+  defp handle_end_element(
+         [{tag_name, text, children}, {parent_tag_name, parent_text, parent_children} | rest],
+         true
+       ) do
+    current = {tag_name, format_element_content(text, children)}
+    [{parent_tag_name, parent_text, [current | parent_children]} | rest]
+  end
+
+  defp handle_end_element(
+         [
+           {tag_name, attributes, text, children},
+           {parent_tag_name, parent_attributes, parent_text, parent_children}
+           | rest
+         ],
+         attribute_mode
+       ) do
+    current = {tag_name, format_attribute_element(attributes, text, children, attribute_mode)}
+
+    [
+      {parent_tag_name, parent_attributes, parent_text, [current | parent_children]}
+      | rest
+    ]
+  end
+
+  defp handle_end_document({key, nil, []}, true) do
     %{key => %{}}
   end
-  defp handle_end_document({key, value}, true) do
-    %{key => format_key_value_pairs(value)}
-  end
-  defp handle_end_document({key, attributes, nil}, false) do
-    %{key => format_key_value_pairs(attributes)}
-  end
-  defp handle_end_document({key, attributes, value}, false) do
-    value =
-      format_key_value_pairs(attributes) |> Map.put(@key_content, format_key_value_pairs(value))
-    %{key => value}
+
+  defp handle_end_document({key, text, children}, true) do
+    %{key => format_element_content(text, children)}
   end
 
-  @compile {:inline, simplify_ignore_attribute_opt: 1}
-  defp simplify_ignore_attribute_opt(true), do: true
-  defp simplify_ignore_attribute_opt(false), do: false
-  defp simplify_ignore_attribute_opt({false, _}), do: false
+  defp handle_end_document({key, attributes, nil, []}, attribute_mode) do
+    %{key => format_attributes(attributes, attribute_mode)}
+  end
 
+  defp handle_end_document({key, attributes, text, children}, attribute_mode) do
+    %{
+      key =>
+        attributes
+        |> format_attributes(attribute_mode)
+        |> Map.put(@key_content, format_element_content(text, children))
+    }
+  end
+
+  defp format_attribute_element(attributes, text, children, attribute_mode) do
+    content = format_element_content(text, children)
+    format_attributes_with_content(attributes, content, attribute_mode)
+  end
+
+  defp format_attributes(attributes, false) do
+    list_to_map(attributes, %{})
+  end
+
+  defp format_attributes(attributes, {false, prefix}) do
+    list_to_map_with_prefix(attributes, prefix, %{})
+  end
+
+  defp format_attributes_with_content(attributes, content, false) do
+    list_to_map(attributes, %{@key_content => content})
+  end
+
+  defp format_attributes_with_content(attributes, content, {false, prefix}) do
+    list_to_map_with_prefix(attributes, prefix, %{@key_content => content})
+  end
+
+  defp format_element_content(nil, []), do: nil
+
+  defp format_element_content(text, []) do
+    text_content(text)
+  end
+
+  defp format_element_content(nil, children) do
+    format_key_value_pairs(children)
+  end
+
+  defp format_element_content(text, children) do
+    list_to_map(children, %{@key_content => text_chunks(text)})
+  end
+
+  defp text_content(text) when is_binary(text), do: text
+  defp text_content(text), do: Enum.reverse(text)
+
+  defp text_chunks(text) when is_binary(text), do: [text]
+  defp text_chunks(text), do: Enum.reverse(text)
+
+  defp normalize_ignore_attribute(true), do: true
+  defp normalize_ignore_attribute(false), do: false
+  defp normalize_ignore_attribute({false, ""}), do: false
+  defp normalize_ignore_attribute({false, prefix}), do: {false, prefix}
 end

--- a/test/sax_map_test.exs
+++ b/test/sax_map_test.exs
@@ -477,6 +477,54 @@ defmodule SAXMapTest do
     }
   end
 
+  test "mixed content keeps a child named content" do
+    xml = "<p>before<content>child</content>after</p>"
+
+    {:ok, map} = SAXMap.from_string(xml)
+
+    # Preserve the existing mixed-content behavior: a child named "content"
+    # remains alongside the synthetic text-content entry.
+    assert map == %{"p" => %{"content" => ["child", "before", "after"]}}
+
+    {:ok, map} = SAXMap.from_string(xml, ignore_attribute: {false, "@"})
+
+    assert map == %{
+             "p" => %{
+               "content" => %{
+                 "content" => [
+                   %{"content" => "child"},
+                   "before",
+                   "after"
+                 ]
+               }
+             }
+           }
+  end
+
+  test "nested attributes preserve content-key collisions" do
+    xml = "<root><item content=\"attribute\">text</item></root>"
+
+    {:ok, map} = SAXMap.from_string(xml, ignore_attribute: false)
+
+    assert map == %{
+             "root" => %{
+               "content" => %{
+                 "item" => %{"content" => ["attribute", "text"]}
+               }
+             }
+           }
+
+    {:ok, map} = SAXMap.from_string(xml, ignore_attribute: {false, "@"})
+
+    assert map == %{
+             "root" => %{
+               "content" => %{
+                 "item" => %{"@content" => "attribute", "content" => "text"}
+               }
+             }
+           }
+  end
+
   test "text node starting with newline" do
     xml = """
     <xml>


### PR DESCRIPTION
This PR includes some code refactoring and cleanup; the comparison while maintaining the same logic is as follows:

In bench folder, execute `mix run refactor_comparison.exs`

```
Operating System: macOS
CPU Information: Apple M2 Pro
Number of Available Cores: 10
Available memory: 16 GB
Elixir 1.19.5
Erlang 28.2
JIT enabled: true

Benchmark suite executing with the following configuration:
warmup: 2 s
time: 10 s
memory time: 2 s
reduction time: 0 ns
parallel: 1
inputs: alternating mixed content, attribute-dense, attribute-dense with @ prefix
Estimated total run time: 1 min 24 s

Benchmarking After refactor with input alternating mixed content ...
Benchmarking After refactor with input attribute-dense ...
Benchmarking After refactor with input attribute-dense with @ prefix ...
Benchmarking Before refactor with input alternating mixed content ...
Benchmarking Before refactor with input attribute-dense ...
Benchmarking Before refactor with input attribute-dense with @ prefix ...
Calculating statistics...
Formatting results...

##### With input alternating mixed content #####
Name                      ips        average  deviation         median         99th %
After refactor         544.01        1.84 ms     ±9.98%        1.84 ms        2.29 ms
Before refactor        277.69        3.60 ms    ±11.73%        3.50 ms        4.71 ms

Comparison:
After refactor         544.01
Before refactor        277.69 - 1.96x slower +1.76 ms

Memory usage statistics:

Name               Memory usage
After refactor          6.04 MB
Before refactor        18.47 MB - 3.06x memory usage +12.43 MB

**All measurements for memory usage were the same**

##### With input attribute-dense #####
Name                      ips        average  deviation         median         99th %
After refactor         535.29        1.87 ms    ±10.34%        1.83 ms        2.28 ms
Before refactor        518.95        1.93 ms     ±7.35%        1.87 ms        2.38 ms

Comparison:
After refactor         535.29
Before refactor        518.95 - 1.03x slower +0.0588 ms

Memory usage statistics:

Name               Memory usage
After refactor          3.40 MB
Before refactor         3.59 MB - 1.05x memory usage +0.183 MB

**All measurements for memory usage were the same**

##### With input attribute-dense with @ prefix #####
Name                      ips        average  deviation         median         99th %
After refactor         250.33        3.99 ms     ±8.77%        3.92 ms        5.17 ms
Before refactor        234.12        4.27 ms     ±9.85%        4.25 ms        5.22 ms

Comparison:
After refactor         250.33
Before refactor        234.12 - 1.07x slower +0.28 ms

Memory usage statistics:

Name               Memory usage
After refactor          3.77 MB
Before refactor         4.27 MB - 1.13x memory usage +0.50 MB

**All measurements for memory usage were the same**
```